### PR TITLE
Update to support webpack v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function(content) {
         // in webpack v2, this.query comes in the following format: { enablecache: false }
         if (typeof(this.query.enablecache) === 'boolean') {
             isCacheEnabled = this.query.enablecache;
-        } else {
+        } else if (typeof(this.query) === 'string') {
             // in webpack v1, this.query comes in the following format: ?{"enablecache":false}
             query = JSON.parse(this.query.slice(1));
             isCacheEnabled = query.enablecache;

--- a/index.js
+++ b/index.js
@@ -18,9 +18,14 @@ module.exports = function(content) {
     id = matches.length ? matches[1] : id;
 
     if (this.query) {
-        // this.query comes in the following format: ?{"enablecache":false}
-        query = JSON.parse(this.query.slice(1));
-        isCacheEnabled = query.enablecache;
+        // in webpack v2, this.query comes in the following format: { enablecache: false }
+        if (typeof(this.query.enablecache) === 'boolean') {
+            isCacheEnabled = this.query.enablecache;
+        } else {
+            // in webpack v1, this.query comes in the following format: ?{"enablecache":false}
+            query = JSON.parse(this.query.slice(1));
+            isCacheEnabled = query.enablecache;
+        }
     }
 
     // Checking for cached template


### PR DESCRIPTION
Queries passed by webpack v2 no longer have a trailing '?' at the beginning of the query. An update is needed to support both webpack v1 and v2.